### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ TensorTrade requires Python >= 3.6 for all functionality to work as expected.
 
 ```bash
 pip install -r requirements.txt
+ -OR-
+pip3 install -r requirements.txt
+
 ```
 
 ---


### PR DESCRIPTION
pip might using python 2.7 to install your requirement.

otherwise will cause like on my side:
~/projects/tensortrade$ pip install -r requirements.txt
Collecting numpy==1.17.0 (from -r requirements.txt (line 1))
  Could not find a version that satisfies the requirement numpy==1.17.0 (from -r requirements.txt (line 1)) (from versions: 1.3.0, 1.4.1, 1.5.0, 1.5.1, 1.6.0, 1.6.1, 1.6.2, 1.7.0, 1.7.1, 1.7.2, 1.8.0, 1.8.1, 1.8.2, 1.9.0, 1.9.1, 1.9.2, 1.9.3, 1.10.0, 1.10.0.post2, 1.10.1, 1.10.2, 1.10.3, 1.10.4, 1.11.0b3, 1.11.0rc1, 1.11.0rc2, 1.11.0, 1.11.1rc1, 1.11.1, 1.11.2rc1, 1.11.2, 1.11.3, 1.12.0b1, 1.12.0rc1, 1.12.0rc2, 1.12.0, 1.12.1rc1, 1.12.1, 1.13.0rc1, 1.13.0rc2, 1.13.0, 1.13.1, 1.13.3, 1.14.0rc1, 1.14.0, 1.14.1, 1.14.2, 1.14.3, 1.14.4, 1.14.5, 1.14.6, 1.15.0rc1, 1.15.0rc2, 1.15.0, 1.15.1, 1.15.2, 1.15.3, 1.15.4, 1.16.0rc1, 1.16.0rc2, 1.16.0, 1.16.1, 1.16.2, 1.16.3, 1.16.4, 1.16.5)
No matching distribution found for numpy==1.17.0 (from -r requirements.txt (line 1))


