### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/tensortrade/exchanges/live/ccxt_exchange.py
+++ b/tensortrade/exchanges/live/ccxt_exchange.py
@@ -157,10 +157,10 @@ class CCXTExchange(InstrumentExchange):
 
         max_wait_time = time.time() + self._max_trade_wait_in_sec
 
-        while order['status'] is 'open' and time.time() < max_wait_time:
+        while order['status'] == 'open' and time.time() < max_wait_time:
             order = self._exchange.fetch_order(order.id)
 
-        if order['status'] is 'open':
+        if order['status'] == 'open':
             self._exchange.cancel_order(order.id)
 
         self._performance = self._performance.append({

--- a/tensortrade/rewards/risk_adjusted_return_strategy.py
+++ b/tensortrade/rewards/risk_adjusted_return_strategy.py
@@ -37,9 +37,9 @@ class RiskAdjustedReturnStrategy(RewardStrategy):
         self._target_returns = target_returns
 
     def _return_algorithm_from_str(self, algorithm_str: str) -> Callable[[pd.DataFrame], float]:
-        if algorithm_str is 'sharpe':
+        if algorithm_str == 'sharpe':
             return self._sharpe_ratio
-        elif algorithm_str is 'sortino':
+        elif algorithm_str == 'sortino':
             return self._sortino_ratio
 
     def _sharpe_ratio(self, returns: pd.Series) -> float:


### PR DESCRIPTION
Identity is not the same thing as equality in Python.

[Porting to Python 3.8](https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8)
> The compiler now produces a SyntaxWarning when identity checks (is and is not) are used with certain types of literals (e.g. strings, numbers). These can often work by accident in CPython, but are not guaranteed by the language spec. The warning advises users to use equality tests (== and !=) instead. (Contributed by Serhiy Storchaka in bpo-34850.)

[flake8](http://flake8.pycqa.org) testing of https://github.com/notadamking/tensortrade on Python 3.8.0

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./tensortrade/rewards/risk_adjusted_return_strategy.py:40:12: F632 use ==/!= to compare str, bytes, and int literals
        if algorithm_str is 'sharpe':
           ^
./tensortrade/rewards/risk_adjusted_return_strategy.py:42:14: F632 use ==/!= to compare str, bytes, and int literals
        elif algorithm_str is 'sortino':
             ^
./tensortrade/exchanges/live/ccxt_exchange.py:160:15: F632 use ==/!= to compare str, bytes, and int literals
        while order['status'] is 'open' and time.time() < max_wait_time:
              ^
./tensortrade/exchanges/live/ccxt_exchange.py:163:12: F632 use ==/!= to compare str, bytes, and int literals
        if order['status'] is 'open':
           ^
4     F632 use ==/!= to compare str, bytes, and int literals
4
```