### PR TITLE
Fix `window_size` larger then 1 in `SimulatedExchange`

### DIFF
--- a/tensortrade/exchanges/simulated/simulated_exchange.py
+++ b/tensortrade/exchanges/simulated/simulated_exchange.py
@@ -216,4 +216,4 @@ class SimulatedExchange(InstrumentExchange):
         self._trades = pd.DataFrame([], columns=['step', 'symbol', 'type', 'amount', 'price'])
         self._performance = pd.DataFrame([], columns=['balance', 'net_worth'])
 
-        self._current_step = 0
+        self._current_step = self._window_size - 1


### PR DESCRIPTION
Any value for `window_size` larger than `1` currently causes the `SimulatedExchange` implementation to return empty data frames for the first few steps (empty data frames, not data frames filled with NaNs, but data frames without any columns). But, any `FeatureTransformer` expects a data frame to exactly fit the observation space, which thus causes any training to crash.

The issue itself is caused by [Line 128](https://github.com/notadamking/tensortrade/blob/master/tensortrade/exchanges/simulated/simulated_exchange.py#L128), which generates the observations:

```obs = self._data_frame.iloc[step - self._window_size + 1:step + 1]```

With any value for `window_size` greater than 1, this line will query negative index at the first step. For example something like [-5:1] for a window of 6 at step 0. Pandas reacts to such a non-sense query with always returning a data frame without any columns.

However, a fix is easy to implement: Don't start with step `0`, but start from `window_size - 1`. Thus all this patch does is change the step value set in the `reset()`-method of `SimulatedExchange`.
