### PR TITLE
fixed broken episode_callback in stable_baselines_strategy.py

### DIFF
--- a/tensortrade/strategies/stable_baselines_strategy.py
+++ b/tensortrade/strategies/stable_baselines_strategy.py
@@ -109,7 +109,7 @@ class StableBaselinesTradingStrategy(TradingStrategy):
             performance = exchange_performance if len(exchange_performance) > 0 else performance
 
             if dones[0]:
-                if episode_callback is not None and episode_callback(self._environment._exchange.performance):
+                if episode_callback is not None and not episode_callback(performance):
                     break
 
                 episodes_completed += 1


### PR DESCRIPTION
the current statement eposide_callback(self._environment._exchange.performance) on line number 112 isnt working
Changed it to episode_callback(performance) since they're technically same things

also, episode_callback() returning true (as per the documentation) breaks the loop (which should be reverse) .. added a not in the if condition.