### PR TITLE
make sure to get the expected data frame length

### DIFF
--- a/tensortrade/exchanges/simulated/fbm_exchange.py
+++ b/tensortrade/exchanges/simulated/fbm_exchange.py
@@ -39,12 +39,22 @@ class FBMExchange(SimulatedExchange):
         self._start_date = self.default('start_date', '2010-01-01', kwargs)
         self._start_date_format = self.default('start_date_format', '%Y-%m-%d', kwargs)
         self._times_to_generate = self.default('times_to_generate', 100000, kwargs)
+        self._maintain_data_frame_len = self.default('maintain_data_frame_len', True, kwargs)
         self._hurst = self.default('hurst', 0.61, kwargs)
-        self._timeframe = self.default('timeframe', '1h', kwargs)
+        self._timeframe = self.default('timeframe', '1h', kwargs)        
 
         self._generate_price_history()
 
     def _generate_price_history(self):
+        if self._maintain_data_frame_len:
+            if 'min' in self._timeframe:
+                self._times_to_generate *= int(self._timeframe[0])
+            elif 'H' in self._timeframe:
+                self._times_to_generate *= int(self._timeframe[0]) * 60
+            elif 'D' in self._timeframe:
+                self._times_to_generate *= int(self._timeframe[0]) * 60 * 24
+            else:
+                raise ValueError('If using maintain_data_frame_len than Timeframe must be either in minutes (min), Hours (H) or Days (D)')
         try:
             price_fbm = FractionalBrownianMotion(t=self._times_to_generate, hurst=self._hurst)
             volume_gen = GaussianNoise(t=self._times_to_generate)
@@ -75,8 +85,11 @@ class FBMExchange(SimulatedExchange):
         volume_frame.set_index('date')
         volume_frame.index = pd.to_datetime(volume_frame.index, unit='m', origin=start_date)
 
-        data_frame = price_frame['price'].resample(self._timeframe).ohlc()
-        data_frame['volume'] = volume_frame['volume'].resample(self._timeframe).sum()
+        data_frame = price_frame['price']
+        data_frame['volume'] = volume_frame['volume']
+        if self._timeframe != '1min':
+            data_frame = price_frame['price'].resample(self._timeframe).ohlc()
+            data_frame['volume'] = volume_frame['volume'].resample(self._timeframe).sum()           
 
         self.data_frame = data_frame.astype(self._dtype)
 


### PR DESCRIPTION
1. a simple addition to make sure that the data_frame.shape(0) == times_to_generate Independent of time frame
2. Reduce unnecessary computation