### PR TITLE
make sure to get the expected data frame length

### DIFF
--- a/tensortrade/exchanges/simulated/fbm_exchange.py
+++ b/tensortrade/exchanges/simulated/fbm_exchange.py
@@ -14,6 +14,7 @@
 
 import pandas as pd
 import numpy as np
+import re
 
 from math import pi
 from gym import spaces
@@ -48,12 +49,12 @@ class FBMExchange(SimulatedExchange):
 
     def _generate_price_history(self):
         if self._maintain_data_frame_len:
-            if 'min' in self._timeframe:
-                self._times_to_generate = self._init_times_to_generate * int(self._timeframe[0])
+            if 'min' in self._timeframe:                
+                self._times_to_generate = self._init_times_to_generate * int(re.findall('\d+', self._timeframe)[0])
             elif 'H' in self._timeframe:
-                self._times_to_generate = self._init_times_to_generate * int(self._timeframe[0]) * 60
+                self._times_to_generate = self._init_times_to_generate * int(re.findall('\d+', self._timeframe)[0]) * 60
             elif 'D' in self._timeframe:
-                self._times_to_generate = self._init_times_to_generate * int(self._timeframe[0]) * 60 * 24
+                self._times_to_generate = self._init_times_to_generate * int(re.findall('\d+', self._timeframe)[0]) * 60 * 24
             else:
                 raise ValueError('If using maintain_data_frame_len than Timeframe must be either in minutes (min), Hours (H) or Days (D)')
         try:

--- a/tensortrade/exchanges/simulated/fbm_exchange.py
+++ b/tensortrade/exchanges/simulated/fbm_exchange.py
@@ -39,7 +39,7 @@ class FBMExchange(SimulatedExchange):
         self._start_date = self.default('start_date', '2010-01-01', kwargs)
         self._start_date_format = self.default('start_date_format', '%Y-%m-%d', kwargs)
         self._times_to_generate = self.default('times_to_generate', 100000, kwargs)
-        self._maintain_data_frame_len = self.default('maintain_data_frame_len', True, kwargs)
+        self._maintain_data_frame_len = self.default('maintain_data_frame_len', False, kwargs)
         self._hurst = self.default('hurst', 0.61, kwargs)
         self._timeframe = self.default('timeframe', '1h', kwargs)
 

--- a/tensortrade/exchanges/simulated/fbm_exchange.py
+++ b/tensortrade/exchanges/simulated/fbm_exchange.py
@@ -39,7 +39,8 @@ class FBMExchange(SimulatedExchange):
         self._start_date = self.default('start_date', '2010-01-01', kwargs)
         self._start_date_format = self.default('start_date_format', '%Y-%m-%d', kwargs)
         self._times_to_generate = self.default('times_to_generate', 100000, kwargs)
-        self._maintain_data_frame_len = self.default('maintain_data_frame_len', False, kwargs)
+        self._init_times_to_generate = self._times_to_generate
+        self._maintain_data_frame_len = self.default('maintain_data_frame_len', False, kwargs)        
         self._hurst = self.default('hurst', 0.61, kwargs)
         self._timeframe = self.default('timeframe', '1h', kwargs)
 
@@ -48,11 +49,11 @@ class FBMExchange(SimulatedExchange):
     def _generate_price_history(self):
         if self._maintain_data_frame_len:
             if 'min' in self._timeframe:
-                self._times_to_generate *= int(self._timeframe[0])
+                self._times_to_generate = self._init_times_to_generate * int(self._timeframe[0])
             elif 'H' in self._timeframe:
-                self._times_to_generate *= int(self._timeframe[0]) * 60
+                self._times_to_generate = self._init_times_to_generate * int(self._timeframe[0]) * 60
             elif 'D' in self._timeframe:
-                self._times_to_generate *= int(self._timeframe[0]) * 60 * 24
+                self._times_to_generate = self._init_times_to_generate * int(self._timeframe[0]) * 60 * 24
             else:
                 raise ValueError('If using maintain_data_frame_len than Timeframe must be either in minutes (min), Hours (H) or Days (D)')
         try:


### PR DESCRIPTION
1. a simple addition to make sure that the data_frame.shape(0) == times_to_generate Independent of time frame
2. Reduce unnecessary computation