### PR TITLE
no change values are designated by feature_midpoint, not 0. oops.

### DIFF
--- a/tensortrade/features/scalers/percent_change_normalizer.py
+++ b/tensortrade/features/scalers/percent_change_normalizer.py
@@ -64,7 +64,7 @@ class PercentChangeNormalizer(FeatureTransformer):
                 feature_scale = 1 / (self._feature_max - self._feature_min)
 
             normalized_column = feature_scale * X[column].pct_change() + feature_midpoint
-            normalized_column = normalized_column.fillna(0)
+            normalized_column = normalized_column.fillna(feature_midpoint)
             normalized_column = normalized_column.clip(lower=self._feature_min,
                                                        upper=self._feature_max)
 


### PR DESCRIPTION
the default value should be feature_midpoint; zeros are likely to be very confusing for anything working with the data